### PR TITLE
Show culprits for disk not ejecting properly

### DIFF
--- a/SLController.m
+++ b/SLController.m
@@ -16,6 +16,7 @@
 #import <MASShortcut/Shortcut.h>
 #import "SLPreferenceKeys.h"
 #import <Sparkle/Sparkle.h>
+#include "SLListCulprits.h"
 
 static inline NSString *stringOrEmpty(NSString *str) {
     return str ? str : @"";
@@ -667,7 +668,10 @@ static inline NSString *stringOrEmpty(NSString *str) {
             NSError *err = nil;
             if (![[NSWorkspace sharedWorkspace] unmountAndEjectDeviceAtURL:[NSURL fileURLWithPath:volume.path] error:&err] && uiFeedback) {
                 NSString *title = [NSString stringWithFormat:NSLocalizedString(@"Failed to unmount %@.", nil), volume.name];
-                [self runAlertWithTitle:title message:[err localizedDescription]];
+                NSString* message = [NSString stringWithFormat:@"%@\n%@",
+                                     [err localizedDescription],
+                                     listCulprits(volume.name)];
+                [self runAlertWithTitle:title message:message];
             }
             return;
         }
@@ -688,7 +692,9 @@ static inline NSString *stringOrEmpty(NSString *str) {
                 diskName = disk.diskID;
             }
             NSString *title = [NSString stringWithFormat:NSLocalizedString(@"Failed to unmount %@.", nil), diskName];
-            [self runAlertWithTitle:title message:nil];
+            NSString* message = [NSString stringWithFormat:@"Possible culprits:\n%@",
+                                 listCulprits(diskName)];
+            [self runAlertWithTitle:title message:message];
         }
     }];
 }

--- a/SLListCulprits.h
+++ b/SLListCulprits.h
@@ -1,0 +1,16 @@
+//
+//  SLListCulprits.h
+//  Semulov
+//
+//  Created by 박현우 on 2021/04/03.
+//  Copyright © 2021 Kevin Wojniak. All rights reserved.
+//
+
+#ifndef SLListCulprits_h
+#define SLListCulprits_h
+
+
+// I'm not an OBJ-c coder. Sorry for exporting raw functions :(
+NSString* listCulprits(NSString* volumeName);
+
+#endif /* SLListCulprits_h */

--- a/SLListCulprits.m
+++ b/SLListCulprits.m
@@ -1,0 +1,49 @@
+#import <Foundation/Foundation.h>
+
+NSString* shell(NSString* command) {
+    NSTask* task = [NSTask new];
+    NSPipe* pipe = [NSPipe new];
+    
+    task.standardOutput = pipe;
+    task.standardError = pipe;
+    task.arguments = [NSArray arrayWithObjects: @"-c", command, nil];
+    task.launchPath = [NSString stringWithUTF8String:"/bin/zsh"];
+    [task launch];
+    
+    
+    NSData* data = [pipe.fileHandleForReading readDataToEndOfFile];
+    NSString* output = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    return output;
+}
+
+NSString* listCulprits(NSString* volumeName) {
+    NSString* prefix = [NSString stringWithFormat:@"/Volumes/%@/", volumeName];
+    NSArray* lsofLines = [shell(@"lsof -Fcnp") componentsSeparatedByString:@"\n"];
+    
+    NSString* command = nil;
+    NSString* path = nil;
+    NSMutableSet<NSString*>* commandSet = [NSMutableSet setWithCapacity: 30];
+    
+    for(NSString* line in lsofLines) {
+        if ([line length] == 0) continue;
+        NSUInteger c = [line characterAtIndex:0];
+        NSString* v = [line substringFromIndex: 1];
+        
+        if (c == 'p') {
+            command = nil;
+            path = nil;
+        } else if ( c == 'c') {
+            command = v;
+        } else if (c == 'n') {
+            path = v;
+            
+            if ([path hasPrefix:prefix]) {
+                [commandSet addObject: command];
+            }
+        }
+    }
+
+    NSArray* commandList =  [commandSet allObjects];
+    commandList = [commandList sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+    return [commandList componentsJoinedByString:@"\n"];
+}

--- a/Semulov.xcodeproj/project.pbxproj
+++ b/Semulov.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		04DE4A7A261780FC005C2008 /* SLListCulprits.m in Sources */ = {isa = PBXBuildFile; fileRef = 04DE4A79261780FC005C2008 /* SLListCulprits.m */; };
 		414805DD200AF50600EA8E8F /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 414805CC200AF50600EA8E8F /* Security.framework */; };
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
@@ -75,6 +76,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		04DE4A78261780FC005C2008 /* SLListCulprits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLListCulprits.h; sourceTree = "<group>"; };
+		04DE4A79261780FC005C2008 /* SLListCulprits.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLListCulprits.m; sourceTree = "<group>"; };
 		089C165DFE840E0CC02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -133,6 +136,8 @@
 		080E96DDFE201D6D7F000001 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				04DE4A78261780FC005C2008 /* SLListCulprits.h */,
+				04DE4A79261780FC005C2008 /* SLListCulprits.m */,
 				29B97316FDCFA39411CA2CEA /* main.m */,
 				A5455F8A0AFE64C6001F61C8 /* SLController.h */,
 				A5455F8B0AFE64C6001F61C8 /* SLController.m */,
@@ -341,6 +346,7 @@
 				A5455FE70AFE66A1001F61C8 /* SLVolume.m in Sources */,
 				A54561870AFE720D001F61C8 /* SLNotificationController.m in Sources */,
 				A58BD52014100451007E9DF9 /* SLDiskManager.m in Sources */,
+				04DE4A7A261780FC005C2008 /* SLListCulprits.m in Sources */,
 				A5779DD5144DE76E00FB1D37 /* NSTaskAdditions.m in Sources */,
 				A5D305B1203A9141001C482D /* NSApplication+LoginItems.m in Sources */,
 				A58DAA47197C4C7100DCC2CA /* SLDiskImageManager.m in Sources */,


### PR DESCRIPTION
<img width="372" alt="Greenshot 2021-04-03 12 15 24" src="https://user-images.githubusercontent.com/775265/113466457-f147d300-9476-11eb-8f0b-150229eed3bc.png">

Show what applications are locking the volume.

No i18n yet (I dunno how). Since I'm a C++ developer I haven't followed the objective-C coding style that much, so please bear the bad code style in mind :)

Basically, this `lsof`s all the open file handles and check what is related to the current releasing drive.